### PR TITLE
Adjust cash on hand order percentage

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -44,6 +44,9 @@ const PORTFOLIO_CONFIG = {
     MIN_PERCENT: 0.03, // 3% of portfolio per position
     DEFAULT_MAX_PERCENT: 0.12,
   },
+  UTILIZATION: {
+    TARGET_PERCENT: 1.0, // Target proportion of portfolio invested (e.g., 1.0 = 100%)
+  },
   RISK_MANAGEMENT: {
     STOP_LOSS_MIN: 0.2, // 20% below entry
     STOP_LOSS_MAX: 0.3, // 30% below entry

--- a/src/handlers/api/trigger-daily-trading.js
+++ b/src/handlers/api/trigger-daily-trading.js
@@ -25,6 +25,52 @@ async function executeTrades(decisions, brokerageService, logger) {
 
   const results = [];
 
+  // Enforce portfolio-level utilization target for BUY orders
+  try {
+    const portfolioService = new PortfolioService();
+    const portfolio = await portfolioService.getCurrentPortfolio();
+    const { PORTFOLIO_CONFIG } = require("../../config/constants");
+
+    const targetInvestedValue =
+      (portfolio.totalValue || 0) * (PORTFOLIO_CONFIG?.UTILIZATION?.TARGET_PERCENT ?? 1.0);
+    const currentInvestedValue = (portfolio.totalValue || 0) - (portfolio.cash || 0);
+    let remainingBudget = Math.max(0, targetInvestedValue - currentInvestedValue);
+
+    // Pre-fetch prices for BUY decisions to compute spend
+    const buyDecisions = decisions.filter((d) => d.action === "BUY");
+    const tickers = [...new Set(buyDecisions.map((d) => d.ticker))];
+    const marketDataService = new MarketDataService();
+    const md = await marketDataService.getPortfolioMarketData({ positions: tickers.map((t) => ({ ticker: t })) });
+
+    // Adjust shares if needed to not exceed remainingBudget
+    for (const d of buyDecisions) {
+      const series = md[d.ticker]?.data;
+      const price = series && series.length > 0 ? series[series.length - 1].close : null;
+      if (!price || !Number.isFinite(price) || !Number.isFinite(d.shares)) continue;
+      const intendedCost = d.shares * price;
+      if (intendedCost > remainingBudget && remainingBudget > 0) {
+        const adjustedShares = Math.floor(remainingBudget / price);
+        if (adjustedShares >= 1) {
+          logger.info(
+            `Adjusting ${d.ticker} shares from ${d.shares} to ${adjustedShares} to respect utilization target`
+          );
+          d.shares = adjustedShares;
+          remainingBudget -= adjustedShares * price;
+        } else {
+          // No budget left for at least 1 share; convert to HOLD
+          logger.info(
+            `Skipping ${d.ticker} BUY due to utilization cap; insufficient remaining budget`
+          );
+          d.action = "HOLD";
+        }
+      } else if (intendedCost <= remainingBudget) {
+        remainingBudget -= intendedCost;
+      }
+    }
+  } catch (e) {
+    logger.warn("Utilization enforcement skipped due to error", e?.message || e);
+  }
+
   for (const decision of decisions) {
     try {
       // Skip HOLD decisions


### PR DESCRIPTION
Add a portfolio-level cash utilization target to allow users to configure the proportion of their portfolio to be invested.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ad1dc9d-29de-4481-9dbd-1fff71e5aaad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ad1dc9d-29de-4481-9dbd-1fff71e5aaad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

